### PR TITLE
Url encoding and language removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Unofficial client for interacting with [What3Words](https://what3words.com/) [AP
 Go 1.13+ required. To start off get the package using `go get` or add it to your `go.mod`.
 
 ```bash
-go get github.com/cpl/go-w3w
+go get github.com/eljoth/go-w3w
 ```
 
 Then simply create a client and use the methods.
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/cpl/go-w3w/pkg/client"
+	"github.com/eljoth/go-w3w/pkg/client"
 )
 
 var address = "filled.count.soap"

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/cpl/go-w3w
+module github.com/eljoth/go-w3w
 
-go 1.14
+go 1.17

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/cpl/go-w3w/pkg/w3w"
 )
@@ -23,6 +24,7 @@ func New(key string) *Client {
 }
 
 func (c *Client) ConvertToCoordinates(address string) (*w3w.ResponseConvert, error) {
+	address=url.QueryEscape(address)
 	req, err := c.newRequest(
 		http.MethodGet,
 		"convert-to-coordinates?words="+address, nil)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/cpl/go-w3w/pkg/w3w"
+	"github.com/eljoth/go-w3w/pkg/w3w"
 )
 
 const EndpointDefault = "https://api.what3words.com/v3/"

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -12,14 +12,12 @@ const EndpointDefault = "https://api.what3words.com/v3/"
 
 type Client struct {
 	Endpoint string
-	Language string
 	key      string
 }
 
 func New(key string) *Client {
 	return &Client{
 		key:      key,
-		Language: "en",
 		Endpoint: EndpointDefault,
 	}
 }

--- a/pkg/client/util.go
+++ b/pkg/client/util.go
@@ -35,7 +35,6 @@ func (c *Client) newRequest(method, url string, body io.Reader) (*http.Request, 
 		return nil, fmt.Errorf("failed creating new client request, %w", err)
 	}
 
-	req.URL.Query().Add("language", c.Language)
 	req.Header.Set(HeaderAPIKey, c.key)
 
 	return req, nil

--- a/pkg/client/util.go
+++ b/pkg/client/util.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/cpl/go-w3w/pkg/w3w"
+	"github.com/eljoth/go-w3w/pkg/w3w"
 )
 
 const HeaderAPIKey = "X-Api-Key"


### PR DESCRIPTION
Addresses are url encoded now since some languages may contain special characters like german umlauts (ä, ö, ü).
In addition, the language url parameter was removed, since the API recognizes the language automatically.